### PR TITLE
fix nfpm configuration syntax

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -10,12 +10,15 @@ description: |
 vendor: "Francis"
 homepage: "https://github.com/fbegyn/tc_exporter"
 license: "MIT"
-bindir: "/usr/local/bin"
-files:
-  ./tc_exporter.service: "/etc/systemd/system/tc_exporter.service"
-  ./bin/tc_exporter: "/usr/local/bin/tc_exporter"
-config_files:
-  ./config.toml: "/etc/tc_exporter/config.toml"
+contents:
+  - src: ./bin/tc_exporter
+    dst: /usr/local/bin/tc_exporter
+  - src: ./tc_exporter.service
+    dst: /etc/systemd/system/tc_exporter.service
+    type: config
+  - src: ./config.toml
+    dst: /etc/tc_exporter/config.toml
+    type: config
 overrides:
   rpm:
     scripts:


### PR DESCRIPTION
Hi

I have try to build package with Makefile and got this error
```
pureewatk@DESKTOP-7OJPF8O:~/Project/tc_exporter$ make
go build -o bin/tc_exporter -ldflags "-w -s\
        -X main.Branch=master\
        -X main.Revision=ea287bdf90b89e70e4195daf5501bb0df202e5fc\
        -X main.Version=v0.6.0" \
        ./cmd/tc_exporter
nfpm pkg --target tc_exporter.deb
guessing packager from target file extension...
yaml: unmarshal errors:
  line 13: field bindir not found in type nfpm.Config
  line 14: field files not found in type nfpm.Config
  line 17: field config_files not found in type nfpm.Config
make: *** [Makefile:16: package] Error 1
```

I have use nfpm 2.14.0 after check configuration with nfpm documents I found that some configuration have deprecated.
https://goreleaser.com/deprecations/#nfpmsconfig_files

So I already change configuration to fix that deprecate syntax.