### PR TITLE
fix panic if XStats is nil

### DIFF
--- a/collector/q_cbq.go
+++ b/collector/q_cbq.go
@@ -90,7 +90,7 @@ func (col *CbqCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Cbq == nil {
+				if qd.Cbq == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -152,6 +152,10 @@ func (col *CbqCollector) Collect(ch chan<- prometheus.Metric) {
 // CollectObject fetches and updates the data the collector is exporting
 // func (col *CbqCollector) Collect(ch chan<- prometheus.Metric) {
 func (col *CbqCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_choke.go
+++ b/collector/q_choke.go
@@ -96,7 +96,7 @@ func (col *ChokeCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Choke == nil {
+				if qd.Choke == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -170,6 +170,10 @@ func (col *ChokeCollector) Collect(ch chan<- prometheus.Metric) {
 // CollectObject fetches and updates the data the collector is exporting
 // func (col *CbqCollector) Collect(ch chan<- prometheus.Metric) {
 func (col *ChokeCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_codel.go
+++ b/collector/q_codel.go
@@ -124,7 +124,7 @@ func (col *CodelCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Choke == nil {
+				if qd.Choke == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -245,6 +245,10 @@ func (col *CodelCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *CodelCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_fq.go
+++ b/collector/q_fq.go
@@ -174,7 +174,7 @@ func (col *FqCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Fq == nil {
+				if qd.Fq == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -367,6 +367,10 @@ func (col *FqCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *FqCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_fqcodel.go
+++ b/collector/q_fqcodel.go
@@ -124,7 +124,7 @@ func (col *FqCodelQdiscCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.FqCodel == nil {
+				if qd.FqCodel == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -245,6 +245,10 @@ func (col *FqCodelQdiscCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *FqCodelQdiscCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_hfsc.go
+++ b/collector/q_hfsc.go
@@ -90,7 +90,7 @@ func (col *HfscCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Hfsc == nil {
+				if qd.Hfsc == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -151,6 +151,10 @@ func (col *HfscCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *HfscCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_htb.go
+++ b/collector/q_htb.go
@@ -96,7 +96,7 @@ func (col *HtbCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Htb == nil {
+				if qd.Htb == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -169,6 +169,10 @@ func (col *HtbCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *HtbCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_pie.go
+++ b/collector/q_pie.go
@@ -118,7 +118,7 @@ func (col *PieCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Pie == nil {
+				if qd.Pie == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -227,6 +227,10 @@ func (col *PieCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *PieCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_red.go
+++ b/collector/q_red.go
@@ -90,7 +90,7 @@ func (col *RedCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Red == nil {
+				if qd.Red == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -151,6 +151,10 @@ func (col *RedCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *RedCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_sfb.go
+++ b/collector/q_sfb.go
@@ -125,7 +125,7 @@ func (col *SfbCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Sfb == nil {
+				if qd.Sfb == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -246,6 +246,10 @@ func (col *SfbCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *SfbCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 

--- a/collector/q_sfq.go
+++ b/collector/q_sfq.go
@@ -67,7 +67,7 @@ func (col *SfqCollector) Collect(ch chan<- prometheus.Metric) {
 
 			// iterate through all the qdiscs and sent the data to the prometheus metric channel
 			for _, qd := range qdiscs {
-				if qd.Sfq == nil {
+				if qd.Sfq == nil || qd.XStats == nil {
 					continue
 				}
 				handleMaj, handleMin := HandleStr(qd.Handle)
@@ -92,6 +92,10 @@ func (col *SfqCollector) Collect(ch chan<- prometheus.Metric) {
 
 // CollectObject fetches and updates the data the collector is exporting
 func (col *SfqCollector) CollectObject(ch chan<- prometheus.Metric, host, ns string, interf rtnetlink.LinkMessage, qd tc.Object) {
+	if qd.XStats == nil {
+		return
+	}
+
 	handleMaj, handleMin := HandleStr(qd.Handle)
 	parentMaj, parentMin := HandleStr(qd.Parent)
 


### PR DESCRIPTION
XStats won't always be set in the qdisc struct coming back from go-tc, so to avoid a panic when this situation occurs, this patch checks if XStats is nil before accessing members of this struct.

```
tc_exporter[245842]: panic: runtime error: invalid memory address or nil pointer dereference
tc_exporter[245842]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x91bf79]
tc_exporter[245842]: goroutine 41 [running]:
tc_exporter[245842]: github.com/fbegyn/tc_exporter/collector.(*HtbCollector).CollectObject(_, _, {_, _}, {_, _}, {0x0, 0x1, 0x3, 0x11043, ...}, ...)
tc_exporter[245842]:         github.com/fbegyn/tc_exporter/collector/q_htb.go:178 +0x1f9
tc_exporter[245842]: github.com/fbegyn/tc_exporter/collector.TcCollector.Collect({{{0xb73b50, 0xc00014a1b8}}, 0xc00021a5a0, 0xc00021aa20}, 0xc000231650)
tc_exporter[245842]:         github.com/fbegyn/tc_exporter/collector/collector.go:205 +0xb63
tc_exporter[245842]: github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
tc_exporter[245842]:         github.com/prometheus/client_golang@v1.21.1/prometheus/registry.go:456 +0x105
tc_exporter[245842]: created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 37
tc_exporter[245842]:         github.com/prometheus/client_golang@v1.21.1/prometheus/registry.go:548 +0xbab
```