### PR TITLE
Fix RED qdisc attribute parsing by updating go-tc dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.6
 
 require (
 	github.com/alecthomas/kong v1.10.0
-	github.com/florianl/go-tc v0.4.5
+	github.com/florianl/go-tc v0.4.6-0.20250503080040-d0c05cfe3c86
 	github.com/jsimonetti/rtnetlink v1.4.2
 	github.com/mdlayher/netlink v1.7.2
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/florianl/go-tc v0.4.5 h1:8lvecARs3c/vGee46j0ro8kco98ga9XjwWvXGwlzrXA=
-github.com/florianl/go-tc v0.4.5/go.mod h1:uvp6pIlOw7Z8hhfnT5M4+V1hHVgZWRZwwMS8Z0JsRxc=
+github.com/florianl/go-tc v0.4.6-0.20250503080040-d0c05cfe3c86 h1:8ttarM2+slSVcRGpWkgZ5jbOAXgveF94xM/pJ1JwkwA=
+github.com/florianl/go-tc v0.4.6-0.20250503080040-d0c05cfe3c86/go.mod h1:uvp6pIlOw7Z8hhfnT5M4+V1hHVgZWRZwwMS8Z0JsRxc=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=


### PR DESCRIPTION

### Problem

The application was failing to parse RED (Random Early Detection) queue discipline
attributes with errors like:

```
unmarshalRed()\t4\n\t[0 0 0 0 15 0 0 0]
```

as reported in https://github.com/fbegyn/tc_exporter/issues/14

### Solution

Update to the fixed version of go-tc containing:
https://github.com/florianl/go-tc/commit/d0c05cfe3c86b84371203a1cfc5e564e4cc6ae3d

### Technical Details

The fix includes:

1. Correct unmarshaling of RED qdisc attributes from netlink messages
2. Proper handling of message alignment across different kernel versions
3. Byte order consistency fixes
4. Support for newer kernel RED parameters while maintaining backward compatibility
