### PR TITLE
chore: set up Dependabot for automatic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- Add .github/dependabot.yml configuration
- Enable daily checks for Go modules
- Set PR limit to 10 concurrent update

#16 